### PR TITLE
Change fusebox setting to use terser minification on production builds

### DIFF
--- a/app/templates/fuse.js
+++ b/app/templates/fuse.js
@@ -20,7 +20,7 @@ context(
     class {
         getConfig() {
 
-            let plugins =  [
+            let plugins = [
                 [
                     SassPlugin({
                         outputStyle: this.isProduction && "compressed",
@@ -29,13 +29,13 @@ context(
                         outFile: file => "public/css/" + file,
                         inject: file => `css/${file}`,
                     }),
-                    
+
                 ],
                 EnvPlugin({ NODE_ENV: this.isProduction ? "production" : "development" }),
                 // this.isProduction && WebIndexPlugin(),
                 this.isProduction && QuantumPlugin({
                     css: true,
-                    uglify: true,
+                    uglify: { es6: true },
                     bakeApiIntoBundle: "bundle",
                 }),
             ]


### PR DESCRIPTION
Hey @geratokyo I tested this out last night and it seems to be working. According to the fuse-box docs  setting { es6: true } switches the minifier to Terser, but still compiles down to es5.
I tested on IE11 on my Windows laptop at home and it [seems fine](http://test-hooks.surge.sh)