### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "pm install yo -g npm install generator-studio -g"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 #__Studio Template Generator__
-
+[![Run on Repl.it](https://repl.it/badge/github/geratokyo/generator-studio)](https://repl.it/github/geratokyo/generator-studio)
 ##Getting started
 
 install Yeoman and generator-studio globally


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@gaving/generator-studio).