### PR TITLE
Fix: missing import after initial boilerplate install

### DIFF
--- a/app/templates/src/pages/SinglePage/SinglePage.tsx
+++ b/app/templates/src/pages/SinglePage/SinglePage.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as ReactRedux from 'react-redux';
 import { connect } from 'react-redux';
+import { RouteComponentProps } from 'react-router';
 import { bindActionCreators, Dispatch } from 'redux';
 import { Cemester, iCmsItem } from 'cemester';
 import {
@@ -16,7 +17,7 @@ import { DP } from '../../constants';
 import { SHOW_MENU_DIALOG } from '../../components/ui/Dialog/Utils';
 import { Header } from '../../components/ui/Header/Header';
 
-export interface SinglePageProps extends ReactRedux.DispatchProp<any> {
+export interface SinglePageProps extends ReactRedux.DispatchProp<any>, RouteComponentProps<any> {
     className?: string;
     deeplink: string;
     content: iCmsItem[];


### PR DESCRIPTION
Will fix:
File errors:
└── ./src/pages/SinglePage/SinglePage.tsx
   | ./src/pages/SinglePage/SinglePage.tsx (48,31) (Error:TS2339) Property 'match' does not exist on type 'Readonly<SinglePageProps> & Readonly<{ children?: ReactNode; }>'.
   | ./src/pages/SinglePage/SinglePage.tsx (64,24) (Error:TS2339) Property 'match' does not exist on type 'Readonly<SinglePageProps> & Readonly<{ children?: ReactNode; }>'.
   | ./src/pages/SinglePage/SinglePage.tsx (79,44) (Error:TS2339) Property 'match' does not exist on type 'Readonly<SinglePageProps> & Readonly<{ children?: ReactNode; }>'.
   | ./src/pages/SinglePage/SinglePage.tsx (88,41) (Error:TS2339) Property 'match' does not exist on type 'Readonly<SinglePageProps> & Readonly<{ children?: ReactNode; }>'.

That occurred after initial install